### PR TITLE
Crvfts patch 1

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1643,8 +1643,9 @@ class PokemonGoBot(object):
                  if 'latitude' in fort and 'longitude' in fort]
         # Need to filter out disabled forts!
         forts = filter(lambda x: x["enabled"] is True, forts)
-        forts = filter(lambda x: 'closed' not in fort, forts)
-
+        forts = filter(lambda x: 'closed' not in x, forts)
+        # forts = filter(lambda x: 'closed' not in fort, forts)
+        
         if order_by_distance:
             forts.sort(key=lambda x: distance(
                 self.position[0],
@@ -1671,7 +1672,7 @@ class PokemonGoBot(object):
                  if 'latitude' in fort and 'type' not in fort]
         # Need to filter out disabled gyms!
         forts = filter(lambda x: x["enabled"] is True, forts)
-        forts = filter(lambda x: 'closed' not in fort, forts)
+        forts = filter(lambda x: 'closed' not in x, forts)
         # forts = filter(lambda x: 'type' not in fort, forts)
 
         if order_by_distance:


### PR DESCRIPTION
Summary:
Appears to fix bot from getting stuck moving to a fort. Bot will choose a fort and pursue it. If GymPokemon task is disabled the bot will still spin gym's photodisc.

Resolves:
#6104 #6099 #6065